### PR TITLE
misc: set library pins wider.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 ]
 dependencies = [
     "Django >= 3.1, < 5.0",
-    "django-dynamicsettings==0.0.3",
-    "django-environ==0.10.0",
+    "django-dynamicsettings > 0.0.2",
+    "django-environ > 0.5.0",
     "requests > 2, < 3",
     "tqdm < 5",
     "packageurl-python >= 0.15.1, < 1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
     "Django >= 3.1, < 4.0",
     "django-dynamicsettings==0.0.3",
     "django-environ==0.10.0",
-    "requests==2.31.0",
-    "tqdm==4.66.3",
-    "packageurl-python==0.15.1",
+    "requests > 2, < 3",
+    "tqdm < 5",
+    "packageurl-python >= 0.15.1, < 1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
These are library apps anyway, they should be more flexible when installing, otherwise dependency hell will arise.